### PR TITLE
Ignore comment lines that show up in the cache file

### DIFF
--- a/tldextract.go
+++ b/tldextract.go
@@ -56,7 +56,7 @@ func New(cacheFile string, debug bool) *TLDExtract {
 	newMap := make(map[string]*Trie)
 	rootNode := &Trie{ExceptRule:false, ValidTld:false, matches:newMap}
 	for _, t := range (ts) {
-		if t != "" {
+		if t != "" && !strings.HasPrefix(t, "//") {
 			exceptionRule := t[0] == '!'
 			if exceptionRule {
 				t = t[1:]


### PR DESCRIPTION
Hello,
I ran into an odd problem extracting apex domains recently. I tracked it down to having comments in the cache file (which wasn't downloaded by the library). I realise the download function is supposed to remove comments but in scenarios were the file is downloaded separately it would be useful to be able to ignore the comments. This has been tested with the Mozilla effective_tld.dat file.
In a similar vein, would you be willing to accept a pull to make the downloading optional? I generally want the program to fail if it cannot use or find the file, rather than fall back to the Mozilla one.
Thanks.
